### PR TITLE
Changing bootstrap download task to always download

### DIFF
--- a/tasks/bootstrap.yml
+++ b/tasks/bootstrap.yml
@@ -12,6 +12,7 @@
   get_url:
     url: "{{ sia_blockchain_url }}"
     dest: "{{ sia_consensus_gzip }}"
+    force: yes
     remote_src: True
 
 - name: unzip the consensus database


### PR DESCRIPTION
If consensus.db is missing but the bootstrap package is there, it probably is not the complete download, so we want to overwrite it.